### PR TITLE
Updated winddir to deal with both numerical & alphanumeric…

### DIFF
--- a/wunderground_upload.yaml
+++ b/wunderground_upload.yaml
@@ -215,11 +215,13 @@ variables:
         else (states(sensor_windgust) | float(default=0)) * (0.6213 if unit_of_measurement == 'km/h' else 1) }}
   winddir: >
     {% set candidate_wind_direction = states(sensor_winddir) %}
-    {% if not candidate_wind_direction is number %}
+    {% set wind_direction_float = candidate_wind_direction | float(default=-1) %}
+    {% if wind_direction_float == -1 %}
       {% set directions_map16 = {'N': 0, 'NNE': 22.5, 'NE': 45, 'ENE': 67.5, 'E': 90, 'ESE': 112.5, 'SE': 135, 'SSE': 157.5, 'S': 180, 'SSW': 202.5, 'SW': 225, 'WSW': 247.5, 'W': 270, 'WNW': 292.5, 'NW': 315, 'NNW': 337.5} %}
       {{ directions_map16.get(candidate_wind_direction, '') | float(default=0) }}
     {%- else -%}
-      {{ candidate_wind_direction | float(default=0) }}
+      {{ wind_direction_float }}
+    {%- endif %}
   rainin: >
     {% set unit_of_measurement = state_attr(sensor_rain, 'unit_of_measurement') %}
     {{ sensor_rain if sensor_rain == ''

--- a/wunderground_upload.yaml
+++ b/wunderground_upload.yaml
@@ -214,8 +214,12 @@ variables:
     {{ sensor_windgust if sensor_windgust == ''
         else (states(sensor_windgust) | float(default=0)) * (0.6213 if unit_of_measurement == 'km/h' else 1) }}
   winddir: >
-    {{ sensor_winddir if sensor_winddir == ''
-        else (states(sensor_winddir) | float(default=0)) }}
+    {% set candidate_wind_direction = states(sensor_winddir) %}
+    {% if not candidate_wind_direction is number %}
+      {% set directions_map16 = {'N': 0, 'NNE': 22.5, 'NE': 45, 'ENE': 67.5, 'E': 90, 'ESE': 112.5, 'SE': 135, 'SSE': 157.5, 'S': 180, 'SSW': 202.5, 'SW': 225, 'WSW': 247.5, 'W': 270, 'WNW': 292.5, 'NW': 315, 'NNW': 337.5} %}
+      {{ directions_map16.get(candidate_wind_direction, '') | float(default=0) }}
+    {%- else -%}
+      {{ candidate_wind_direction | float(default=0) }}
   rainin: >
     {% set unit_of_measurement = state_attr(sensor_rain, 'unit_of_measurement') %}
     {{ sensor_rain if sensor_rain == ''


### PR DESCRIPTION
When using the blueprint to upload my Netatmo data, I find the Netatmo anemometer wind direction is reported as compass letters.
For example: N NE E SE S SW W NW W.
This is a proposal to check if the winddir sensor is returning a number.
If yes, it's used .
It not, it's assumed to be an alphabetical direction and it is checked agains a table of 16 possible value.
(N NNE NE ENE etc...), and the corresponding numerical value is returned.

I've tested the updated code in home assistant using developer tools / template.
I haven't tested it as a blueprint (I don't know how).
