### PR TITLE
Change lowercase winddir to uppercase before translating to degrees

### DIFF
--- a/wunderground_upload.yaml
+++ b/wunderground_upload.yaml
@@ -221,6 +221,7 @@ variables:
     {% set wind_direction_float = candidate_wind_direction | float(default=-1) %}
     {% if wind_direction_float == -1 %}
       {% set directions_map16 = {'N': 0, 'NNE': 22.5, 'NE': 45, 'ENE': 67.5, 'E': 90, 'ESE': 112.5, 'SE': 135, 'SSE': 157.5, 'S': 180, 'SSW': 202.5, 'SW': 225, 'WSW': 247.5, 'W': 270, 'WNW': 292.5, 'NW': 315, 'NNW': 337.5} %}
+      {% set candidate_wind_direction = candidate_wind_direction.upper() %}
       {{ directions_map16.get(candidate_wind_direction, '') | float(default=0) }}
     {%- else -%}
       {{ wind_direction_float }}


### PR DESCRIPTION
My Home Assistant Netatmo Wind integration sensor reports wind direction in lower case (i.e. 'n', 'se', 'nnw', etc...) which meant that all directions mapped to 0 degrees since dictionary get is case-sensitive.  This change transforms the wind direction to upper case before using it as a lookup key in the direction-to-degrees map.

Tested by hand in Home Assistant Developer Tools template console against numeric (float and int) inputs and a mixture of valid and invalid uppercase and lowercase wind directions.
